### PR TITLE
Update header.html

### DIFF
--- a/_includes/common/header.html
+++ b/_includes/common/header.html
@@ -4,8 +4,9 @@
                 <div class="top navigation primary">
                     <ul class="links clearfix">
                         <li class="home with-text"><a href="http://www.passbolt.com/"><span>home</span></a></li>
-                        <li class="left"><a href="https://www.passbolt.com/services"><span>pricing</span></a></li>
                         <li class="left"><a href="https://demo.passbolt.com" target="_blank" rel="noopener"><span>demo</span></a></li>
+                        <li class="left"><a href="https://www.passbolt.com/services"><span>pricing</span></a></li>
+                        <li class="left"><a href="https://www.passbolt.com/roadmap"><span>roadmap</span></a></li>
                         <li class="left"><a href="https://www.passbolt.com/blog"><span>blog</span></a></li>
                         <li class="left selected"><a href="//help.passbolt.com/"><span>help</span></a></li>
                     </ul>


### PR DESCRIPTION
The appearing/disappearing "roadmap" and oscillating "demo"/"pricing" links have been bugging me whenever I click around between the help site and the main site. Making the help look closer to the main site seemed an easy change.