### PR TITLE
Added note about GPG keys (backup/restore/import)

### DIFF
--- a/_posts/2018-03-14-hosting-backup-v2.md
+++ b/_posts/2018-03-14-hosting-backup-v2.md
@@ -45,6 +45,12 @@ You can copy the server OpenPGP key in `config/gpg` or export it directly from G
 ```bash
 gpg --export-secret-key -a "passbolt server" > private.key
 ```
+
+##### Note
+
+Be sure to **remove the expiration time** before importing the keys at backup restore. While restoring the backup, the imported keys cannot have an expiry date.
+
+
 #### 4. The application configuration
 
 The file located in `config/passbolt.php`. It is optional, but it can save you some time if you need to rebuild a new instance.


### PR DESCRIPTION
A note was added to backup/export-gpg-keys describing the attribute of the keys.

> [The key cannot have an expiry date.](https://github.com/passbolt/passbolt_api/blob/37369540952fd0046cd400f693ca04ac5b37a188/webroot/js/web_installer/gpg_key_import.js#L118)
