### PR TITLE
invalid argument

### DIFF
--- a/_includes/hosting/docker/docker-usage.md
+++ b/_includes/hosting/docker/docker-usage.md
@@ -25,7 +25,7 @@ volume or a host directory and mount it at `/var/lib/mysql`
 ```bash
 $ docker volume create mariadb_passbolt_data
 $ docker run -d --name mariadb --net passbolt_network \
-             --mount source=mariadb_passbolt_data, \
+             --mount source=mariadb_passbolt_data,\
              target=/var/lib/mysql \
              -e MYSQL_ROOT_PASSWORD=<root_password> \
              -e MYSQL_DATABASE=<mariadb_database> \


### PR DESCRIPTION
invalid argument "source=mariadb_passbolt_data," for "--mount" flag: invalid field '' must be a key=value pair