### PR TITLE
Update healthcheck command in-case-of-issues.md

### DIFF
--- a/_includes/hosting/update/in-case-of-issues.md
+++ b/_includes/hosting/update/in-case-of-issues.md
@@ -10,7 +10,7 @@ Optionally, you can login as an administrator and check the status on the health
 
 You can also run the following command:
 ```bash
-./bin/cake passbolt healthcheck
+$ sudo -H -u www-data bash -c "./bin/cake passbolt healthcheck"
 ```
 
 #### If you run into some issues


### PR DESCRIPTION
If user does not run this command as www-data, it will result in suggestions following file permission warnings which will leave the folders with user:user permissions instead of user:www-data. Although healthcheck will pass, errors will be created because (for example, because tmp folder is not writable by www-data).