### PR TITLE
Update resources-read-index.md

### DIFF
--- a/_pages/api/resources/resources-read-index.md
+++ b/_pages/api/resources/resources-read-index.md
@@ -74,6 +74,42 @@ The endpoint takes the following parameters
             <td>No</td>
             <td>String</td>
         </tr>
+        <tr>
+            <td>filter[]</td>
+            <td>Controls the fields that could be returned</td>
+            <td></td>
+            <td>Array</td>
+        </tr>
+        <tr>
+            <td>filter[is-favorite]</td>
+            <td>Return the results that are marked as favorite</td>
+            <td>No</td>
+            <td>Boolean</td>
+        </tr>
+        <tr>
+            <td>filter[is-shared-with-group]</td>
+            <td>Return the results that are shared with {GROUP_ID}</td>
+            <td>No</td>
+            <td>String</td>
+        </tr>
+        <tr>
+            <td>filter[is-owned-by-me]</td>
+            <td>Return the results that are ownde by me</td>
+            <td>No</td>
+            <td>Boolean</td>
+        </tr>
+        <tr>
+            <td>filter[is-shared-with-me]</td>
+            <td>Return the results that are shared with me</td>
+            <td>No</td>
+            <td>Boolean</td>
+        </tr>
+        <tr>
+            <td>filter[has-id]</td>
+            <td>Return the results with {RESOURCE_ID}</td>
+            <td>No</td>
+            <td>String</td>
+        </tr>
     </tbody>
 </table>
 
@@ -114,6 +150,7 @@ The endpoint takes the following parameters
 It is possible to adjust the request response for example to 
 *   include `creator`, `favorite`, `modifier`, `permission` and `tag`
 *   Sort DESC by resource modification datetime
+*   Filter by `is-favorite`, `is-shared-with-group`, `is-owned-by-me`, `is-shared-with-me` and `has-id`
 *   Using api-version v2
 
 Such request will look like this:
@@ -126,6 +163,7 @@ GET /resources.json?api-version=v2
         &contain[permission]=1
         &contain[tag]=1
         &order[]=Resource.modified DESC
+        &filter[is-shared-with-group]=5269a7d2-f72e-4ae4-ae24-94dacee15298
 ```
 
 ### Success response


### PR DESCRIPTION
added missing filters in api call to get resources.
please look over the last changed line "&filter[is-shared-with-group]=5269a7d2-f72e-4ae4-ae24-94dacee15298". I'm not sure if this is a good idea to put this there, because the linked response would not fit to the request anymore.