### PR TITLE
Update location of user generation for docker-compose

### DIFF
--- a/_includes/hosting/docker/docker-compose-usage.md
+++ b/_includes/hosting/docker/docker-compose-usage.md
@@ -35,7 +35,7 @@ docker-compose ps
 If you run passbolt using [docker-compose{{ page.docker_tag }}.yml](https://github.com/passbolt/passbolt_docker/blob/master/docker-compose{{ page.docker_tag }}.yml) provided by passbolt:
 
 ```bash
-$ docker-compose exec passbolt su -m -c "/usr/share/php/passbolt/bin/cake \
+$ docker-compose exec passbolt su -m -c "/var/www/passbolt/bin/cake \
                                 passbolt register_user \
                                 -u <your@email.com> \
                                 -f <yourname> \


### PR DESCRIPTION
The path provided in the documentation resolves in an error where the `/usr/share/php/passbolt/bin/cake` is a non existing directory. This updates the documentation to point towards the actual installation location of passbolt.

Not sure if you have a template for PR, so please advice if this is the correct approach.