### PR TITLE
Update docker and traefik config

### DIFF
--- a/_includes/configure/configure-docker-https-auto.md
+++ b/_includes/configure/configure-docker-https-auto.md
@@ -37,7 +37,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik.yaml:/traefik.yaml:ro
       - ./conf/:/etc/traefik/conf
-      - ./acme.json:/acme.json
+      - ./shared/:/shared
 ```
 
 Traefik will:
@@ -82,7 +82,7 @@ certificatesResolvers:
   letsencrypt:
     acme:
       email: yourname@domain.tld
-      storage: acme.json
+      storage: /shared/acme.json
       caServer: 'https://acme-v02.api.letsencrypt.org/directory'
       keyType: EC256
       httpChallenge:


### PR DESCRIPTION
Update docker and traefik config to prevent error with the acme.json file. With the old config traefik would create an directory named acme.json which doesn't work out. See here for details: https://williamhayes.medium.com/traefik-letsencrypt-and-acme-json-configuration-problems-5780c914351d