### PR TITLE
Update docker-compose usage with SMTP information.

### DIFF
--- a/_includes/hosting/docker/docker-compose-usage.md
+++ b/_includes/hosting/docker/docker-compose-usage.md
@@ -43,7 +43,7 @@ The `APP_FULL_BASE_URL` environment variable is set by default to [https://passb
 
 Update this variable with the server name you plan to use. You will find at the bottom of this documentation links about how to set your own SSL certificate.
 
-For more information on which environment variables are available on Passbolt, please check the [passbolt environment variable reference](/configure/environment/reference.html){:target="_blank"}.
+For more information on which environment variables are available on Passbolt, please check the [passbolt environment variable reference](/configure/environment/reference.html){:target="_blank"}. Add the `EMAIL_TRANSPORT_*` environment variables to configure SMTP to send mails.
 
 **Step {{ stepNumber }}{% assign stepNumber = stepNumber | plus:1 %}.** Start your containers
 


### PR DESCRIPTION
I added the information about the SMTP environment variables because i first thought a working mail transport on my server should be enough. Needed some time to figure out that i have to set it via environment variables.