### PR TITLE
Update might fail with 'apt upgrade'

### DIFF
--- a/docs/hosting/update/ubuntu-package.html
+++ b/docs/hosting/update/ubuntu-package.html
@@ -221,9 +221,10 @@ such as active users corrupting the data in the middle of an upgrade.</p>
 
     <h3 id="upgrade-your-system">3. Upgrade your system</h3>
 
-    <p>This commands will trigger an upgrade on your whole Ubuntu system:</p>
+    <p>The passbolt update might fail if the database is uptaded in the same run. So "apt upgrade" should be run separately. This commands will trigger an upgrade of the passbolt installation and then the remaining Ubuntu system:</p>
 
     <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nv">$ </span><span class="nb">sudo </span>apt update
+<span class="nv">$ </span><span class="nb">sudo </span>apt --only-upgrade install passbolt-ce-server
 <span class="nv">$ </span><span class="nb">sudo </span>apt upgrade
 </code></pre></div>    </div>
 


### PR DESCRIPTION
Tested on Ubuntu Server 20.04

When mariadb is updated in the same `apt upgrade`-run as passbolt then the database upgrade fails.
```
Setting up passbolt-ce-server (3.8.1-1) ...
Installing new version of config file /etc/passbolt/app.default.php ...
Installing new version of config file /etc/passbolt/app.php ...
Installing new version of config file /etc/passbolt/bootstrap.php ...
Installing new version of config file /etc/passbolt/default.php ...
Installing new version of config file /etc/passbolt/routes.php ...
Installing new version of config file /etc/passbolt/version.php ...

     ____                  __          ____
    / __ \____  _____ ____/ /_  ____  / / /_
   / /_/ / __ `/ ___/ ___/ __ \/ __ \/ / __/
  / ____/ /_/ (__  |__  ) /_/ / /_/ / / /
 /_/    \__,_/____/____/_.___/\____/_/\__/

 Open source password manager for teams
-------------------------------------------------------------------------------
-------------------------------------------------------------------------------
 Running migration scripts.
-------------------------------------------------------------------------------
using migration paths
 - /etc/passbolt/Migrations
using seed paths
 - /etc/passbolt/Seeds
Exception: There was a problem connecting to the database: SQLSTATE[HY000] [2002] Connection refused
In [/usr/share/php/passbolt/vendor/robmorgan/phinx/src/Phinx/Db/Adapter/PdoAdapter.php, line 96]

dpkg: error processing package passbolt-ce-server (--configure):
 installed passbolt-ce-server package post-installation script subprocess returned error exit status 1
```
So passbolt upgade should be triggered before the remaining system.