### PR TITLE
Assign webServerUser value on hosting-update-source

### DIFF
--- a/_posts/hosting/update/2021-02-08-hosting-update-source.md
+++ b/_posts/hosting/update/2021-02-08-hosting-update-source.md
@@ -12,7 +12,7 @@ layout: default
 slug: source
 permalink: /:categories/:slug.html
 ---
-
+{% assign webServerUser = 'www-data' %}
 {% include layout/row_start.html %}
 {% include layout/col_start.html column="7" %}
 


### PR DESCRIPTION
The webServerUser value is used in the Troubleshooting section and without it this command has no user to display:
![image](https://github.com/passbolt/passbolt_help/assets/47018474/7e7d9c18-4000-4352-bb7f-70a3d647d4c6)

This document uses `www-data` already so I choose to continue to use `www-data`.