### PR TITLE
Fix key management commands

### DIFF
--- a/_includes/hosting/backup/backup_from_source_full_page.md
+++ b/_includes/hosting/backup/backup_from_source_full_page.md
@@ -5,10 +5,10 @@
 
 We made a dedicated command in order to make a backup of the database, it uses `mysqldump` but we recommend to use the passbolt command as it has been made to avoid any pasting or logins details errors.
 
-**Replace *WEB_SERVER_USER* with the correct one.** Depending on your OS, it could be nginx, www-data, etc.
+**Replace *<WEB_SERVER_USER>* with the correct one.** Depending on your OS, it could be nginx, www-data, etc.
 
 ```bash
-sudo su -s /bin/bash -c "/var/www/passbolt/bin/cake passbolt mysql_export" WEB_SERVER_USER
+sudo su -s /bin/bash -c "/var/www/passbolt/bin/cake passbolt mysql_export" <WEB_SERVER_USER>
 ```
 
 #### 2. The server public and private keys
@@ -22,14 +22,14 @@ Another method is to export it using GnuPG. You can use the email attached to yo
 In order to find the fingerprint if you do not know the email attached to your keys:
 
 ```bash
-sudo -H -u www-data /bin/bash -c "gpg --list-keys"
+sudo -H -u <WEB_SERVER_USER> /bin/bash -c "gpg --list-keys"
 ```
 
 If you know the email attached to your keys you can use it to export your keys as follows:
 
 ```bash
-sudo -H -u www-data /bin/bash -c "gpg --export-secret-keys <identifier> > /var/www/passbolt/config/gpg/private.asc" www-data
-sudo -H -u www-data /bin/bash -c "gpg --export <identifier> > /var/www/passbolt/config/gpg/public.asc" www-data
+sudo -H -u <WEB_SERVER_USER> /bin/bash -c "gpg --export-secret-keys <identifier> > /var/www/passbolt/config/gpg/private.asc"
+sudo -H -u <WEB_SERVER_USER> /bin/bash -c "gpg --export <identifier> > /var/www/passbolt/config/gpg/public.asc"
 ```
 Where <identifier> can be the key fingerprint or the email associated with the key you want to export.
 


### PR DESCRIPTION
Key management commands had the user duplicated. Also, they had a "hard-coded" username, unlike the commands just a few lines prior. Fixed both. Also adjusted the syntax of the username placeholder to match the "<identifier>" placeholder.